### PR TITLE
docs: improve README and API descriptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run test coverage
         run: pnpm test:coverage
 
+      - name: Verify package contents
+        run: npm pack --dry-run
+
       - name: Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-/src
-/.*
-/example
-/coverage
-/test
-/tsconfig

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmmirror.com

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Orange Mi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -157,17 +157,17 @@ export class ExampleController {
 - `@before((ctx) => Promise<void>)` runs before the next middleware.
 - `@after((ctx) => Promise<void>)` runs after downstream middleware completes successfully.
 
-Decorators of the same kind run from top to bottom. The overall sequence is:
+Within the controller and method scopes, `@before` callbacks and the entry phase of `@middleware` run from top to bottom in the order they are declared. The complete execution sequence is:
 
-1. Controller `@middleware`
-2. Controller `@before`
-3. Method `@middleware`
-4. Method `@before`
-5. Controller method
-6. Method `@after`
-7. Controller `@after`
+1. Controller-level `@before` callbacks and `@middleware` entry phases, in declaration order
+2. Method-level `@before` callbacks and `@middleware` entry phases, in declaration order
+3. Controller method
+4. Method-level `@after` callbacks, from top to bottom
+5. Method-level `@middleware` code after `await next()`, in reverse order
+6. Controller-level `@after` callbacks, from top to bottom
+7. Controller-level `@middleware` code after `await next()`, in reverse order
 
-Standard `@middleware` functions still follow Koa's onion model, so code after `await next()` unwinds in reverse order.
+This follows Koa's onion model while preserving top-to-bottom decorator order within each scope.
 
 ## Loading controllers
 

--- a/README.md
+++ b/README.md
@@ -1,155 +1,409 @@
-@tng/koa-controller
-====
+# @tng/koa-controller
 
-Write koa http server with koa-controller by decorator feature in typescript. Make job easily done in a short time.
+Decorator-based controllers and routing utilities for TypeScript applications built with [Koa](https://koajs.com/). The package includes request-state mapping, AJV validation, request logging, error handling, and OpenTracing middleware.
 
-## Usage Example
+## Installation
 
-```typescript
-// path/to/controller.ts
-import { controller, get } from '@tng/koa-controller'
+```sh
+pnpm add @tng/koa-controller koa koa-bodyparser
+pnpm add -D typescript @types/koa @types/koa-bodyparser @types/koa-router
+```
 
-@controller('/api')
-class UserController {
-  @get('/login')
-  async login() {
-    return 'OK'
+The package targets Node.js 18 or later and uses legacy TypeScript decorators. Enable decorator support in your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "experimentalDecorators": true,
+    "esModuleInterop": true
   }
 }
+```
 
-// path/to/main/koa/server.ts
-import { getRouterSync } from '@tng/koa-controller'
+## Quick start
+
+Create and export a controller. Controller methods receive `ctx.state` as their first argument and the Koa context as their second argument. Their resolved return value becomes `ctx.body`.
+
+```ts
+// src/controllers/user.ts
+import { controller, get } from '@tng/koa-controller'
+
+@controller('/api/users')
+export class UserController {
+  @get('/:id')
+  async getUser(state, ctx) {
+    return {
+      id: ctx.params.id,
+    }
+  }
+}
+```
+
+Load the exported controllers and mount the router:
+
+```ts
+// src/app.ts
+import Koa from 'koa'
+import bodyParser from 'koa-bodyparser'
+import {
+  errorHandlerMW,
+  getRouterAsync,
+  loggerMW,
+} from '@tng/koa-controller'
+
 const app = new Koa()
 
-// inject all related controller files by given glob pattern
-app.use(getRouterSync({
-  files: path.resolve('path/to/controller/**/*.[jt]s'),
-}).routes())
+app.use(loggerMW({ logger: console }))
+app.use(errorHandlerMW({ logger: console }))
+app.use(bodyParser())
 
+const router = await getRouterAsync({
+  files: 'src/controllers/**/*.[jt]s',
+})
+
+app.use(router.routes())
+app.use(router.allowedMethods())
+
+app.listen(4000)
 ```
+
+Use `getRouterAsync` for ESM controllers. For CommonJS projects whose controller files can be loaded with `require()`, use `getRouterSync`:
+
+```ts
+const Koa = require('koa')
+const { getRouterSync } = require('@tng/koa-controller')
+
+const app = new Koa()
+const router = getRouterSync({
+  files: 'src/controllers/**/*.[jt]s',
+})
+
+app.use(router.routes())
+app.use(router.allowedMethods())
+app.listen(4000)
+```
+
+Controllers must be exported from their modules so that the file loader can discover them.
+
+When running TypeScript source files directly, use a TypeScript runtime/loader that supports decorators and dynamic imports. In a compiled deployment, point `files` at the emitted JavaScript instead, for example `dist/controllers/**/*.js`.
 
 ## Router
 
-### @controller(prefix?: string)
-Register a route on a class for router as a controller.
+### `@controller(prefix?: string)`
 
-`NOTE` The router will ignore the route if no route method is provided in the class.
-And for the contrast, the route method will be ignored unless the controller is registed.
+Marks a class as a controller and optionally gives all of its routes a prefix. A class without decorated route methods is ignored, and a decorated method is ignored unless its class has controller metadata.
 
-### @request(verb: string, route: string)
-Register a route on a method for router.
-It will run other middleware as well when route is matched.
-The sequence is in [middleware squence](#middleware-sequence) section.
-
-Method's first parameter is the state of context, or `ctx.state`; second paramenter is the koa context or `ctx` for the request.
-Method should be a thenable async function which return the result for response body.
-
-`NOTE` A method can be registered for multi routes. all the result and the middlewares will be shared.
-
-example:
 ```ts
-class SomeController {
-  @request('get', '/login')
-  async somePath(state, ctx: Context) {
-    // state is for context.state
-    // ctx is for context
-    return result // equivalent to ctx.body = result
+@controller('/api')
+export class HealthController {
+  @get('/health')
+  async health() {
+    return { status: 'ok' }
   }
 }
 ```
 
-### `@before((ctx: KoaContext) => Promise<void>)`
-### `@after((ctx: KoaContext) => Promise<void>)`
-### `@middleware((ctx: KoaContext, next: Promise<void>) => Promise<void>)`
-Register a before middleware, a after middleware or a middleware for a route which register either on method or controller class.
+A controller class is instantiated once when the router is built. Do not keep request-specific mutable state on the instance because it is shared by concurrent requests.
 
-### middleware sequence
-if same decorator written 2 or more times, router will run in sequence from top to bottom.
-Please see `test/router.test.ts` file to learn more about it.
+### `@request(verb?: string, pathname?: string)`
 
-- controller @middleware | @before
-- method @middleware | @before
-- method function
-- method @after
-- controller @after
+Registers a controller method for an HTTP verb and path. The same method can have more than one route decorator.
 
-### `@get(pathname: string)`
-### `@post(pathname)`
-The shortcut for `@request('get', pathname)` and `@request('post', pathname)`
+```ts
+@controller('/sessions')
+export class SessionController {
+  @request('post', '/')
+  async create(state, ctx) {
+    return { created: true }
+  }
+}
+```
 
-### getRouterSync(options): KoaRouter
-Run `require` to require files and return koa router instance.
+Controller methods must be asynchronous/thenable. Their resolved result is assigned to `ctx.body`.
 
-- options: `<Object>`
-  - files: `<String>` glob pattern to run Nodejs's `require` function. glob will base on `cwd` option.
-  - cwd: `<String>` base working directory to run `require` function. Default is `process.cwd()`.
-  - prefix: `<String>` Koa Router contructor's parameter to generate Koa Router.
-  - logger: `<Logger>` Logger has `debug` or `info` method to debug file or functions.
+### `@get(pathname?: string)` and `@post(pathname?: string)`
 
-## Logger (TODO)
+Shortcuts for `@request('get', pathname)` and `@request('post', pathname)`.
 
-## Tracer
-Use `opentracing` implemented tracer instance to cross-platform tracing.
+## Route middleware
 
-### traceMW(tracer: Tracer, options?): KoaMiddleware
-WIP: Use `opentracing` implemented tracer instance to cross-platform tracing.
+Middleware decorators can be applied to a controller class or an individual method:
 
-## Validate
-### @validate(schema: JSONSchema, { ajv: AjvInstance })
-Generate a `@before` middleware to register on a method or controller by using `AJV`.
+```ts
+@controller('/api')
+@before(async ctx => {
+  ctx.set('x-controller', 'example')
+})
+export class ExampleController {
+  @get('/items')
+  @middleware(async (ctx, next) => {
+    const startedAt = Date.now()
+    await next()
+    ctx.set('x-duration', String(Date.now() - startedAt))
+  })
+  @after(async ctx => {
+    ctx.set('x-handler-complete', 'true')
+  })
+  async list() {
+    return []
+  }
+}
+```
 
-Example
+- `@middleware((ctx, next) => Promise<void>)` registers standard Koa middleware.
+- `@before((ctx) => Promise<void>)` runs before the next middleware.
+- `@after((ctx) => Promise<void>)` runs after downstream middleware completes successfully.
+
+Decorators of the same kind run from top to bottom. The overall sequence is:
+
+1. Controller `@middleware`
+2. Controller `@before`
+3. Method `@middleware`
+4. Method `@before`
+5. Controller method
+6. Method `@after`
+7. Controller `@after`
+
+Standard `@middleware` functions still follow Koa's onion model, so code after `await next()` unwinds in reverse order.
+
+## Loading controllers
+
+`getRouterAsync(options)` dynamically imports every matching module and works with `ESM` controller files. `getRouterSync(options)` uses `require()` and is intended for CommonJS-loadable(`CJS`) files.
+
+```ts
+const router = await getRouterAsync({
+  cwd: process.cwd(),
+  files: 'src/controllers/**/*.[jt]s',
+  prefix: '/v1',
+})
+```
+
+Options:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `cwd` | `process.cwd()` | Base directory used when resolving the glob and controller files. |
+| `files` | `api/**/*.[jt]s` | Glob pattern used to discover controller modules. |
+| `prefix` | `''` | Prefix passed to the underlying Koa router. |
+| `logger` | `undefined` | Accepted for API compatibility; controller discovery currently uses the `koa:controller` debug namespace. |
+
+For dependency injection or tests, use `loadRouter` to provide constructors directly:
+
+```ts
+const router = loadRouter({
+  prefix: '/v1',
+  controllerConstructors: [UserController],
+})
+```
+
+Set `DEBUG=koa:controller` to inspect controller discovery and route registration.
+
+## Request State
+
+### `@state(map?)`
+
+Without a map, `@state()` replaces `ctx.state` with a shallow merge of `ctx.query`, `ctx.request.body`, and `ctx.params`. Later sources take precedence, so path parameters override body values and body values override query values.
+
+With a map, only the selected values are copied. Every source path is resolved from the Koa context with `lodash.get`:
+
+```ts
+@controller('/users')
+export class UserController {
+  @get('/:id')
+  @state({
+    userId: ['params.id'],
+    name: ['query.name'],
+    token: ['headers.authorization'],
+  })
+  async getUserInfo(state) {
+    return state
+  }
+}
+```
+
+Each mapping value is an array of context paths. When multiple paths are supplied, they are evaluated from left to right and later values overwrite earlier ones.
+
+## Validation
+
+Validation is powered by [AJV](https://ajv.js.org/). The shared default AJV instance enables `coerceTypes` and `useDefaults`, so validation can modify the validated data.
+
+### `@validate(schema, options?)`
+
+Validates the complete Koa context before invoking the controller method. Invalid input throws an HTTP 400 error containing the first AJV validation message.
+
 ```ts
 @validate({
   type: 'object',
-  require: ['query'],
+  required: ['query'],
   properties: {
     query: {
       type: 'object',
-      require: ['id'],
+      required: ['id'],
       properties: {
         id: { type: 'integer' },
-      }
-    }
-  }
+      },
+    },
+  },
 })
-class SomeController { ... }
 ```
 
-### @validateState(schema: JSONSchema, { ajv: AjvInstance })
-Generate a `@before` middleware to register on a method or controller by using `AJV` but ONLY validate `ctx.state`.
-It should be always be used with `@state()`
+### `@validateState(schema, options?)`
 
-## state
-### @state(map: {[key: string]: PathFromContext/String })
-Generate ctx.state from `ctx.query`, `ctx.params` and `ctx.request.body` if map is undefined.
-If map is provided only mapped key-value pair will be included into state.
+Validates only `ctx.state`. Place `@state()` above `@validateState()` when the state should be built from the incoming request first:
 
-The key in map will be the key in state.
-The value in map will be resolved the value in state by finding the value of context in a certain path.
-Value path maybe provided in a array. It means the order to find a value from context.
-
-example
 ```ts
-class UserController {
-  @get('/users/:id')
-  @state({
-    userId: ['params.id'],
-    age: ['query.name'],
-    token: ['header.authorization'],
+@controller('/users')
+export class UserController {
+  @post('/')
+  @state()
+  @validateState({
+    type: 'object',
+    required: ['name'],
+    properties: {
+      name: { type: 'string', minLength: 1 },
+      age: { type: 'integer', minimum: 0 },
+    },
   })
-  async getUserInfo(state) {
-    // GET /users/123?name=John&age=18
-    state = {
-      userId, // 123 (string)
-      name, // John
-      // age will not be in the state
-      token, // token is undefined unless it passed.
-    }
+  async create(state) {
+    return state
   }
 }
 ```
 
-## Error Handler (TODO)
+Both decorators accept a custom AJV instance:
 
-## Contribution (WIP)
+```ts
+@validateState(schema, { ajv })
+```
+
+### Type-safe validated state
+
+AJV performs runtime validation; it does not automatically infer the controller method parameter type. Define the state type explicitly and use AJV's `JSONSchemaType<T>` to keep the schema consistent with that type. `JSONSchemaType<T>` requires `strictNullChecks` to be enabled in TypeScript.
+
+```ts
+import type { JSONSchemaType } from 'ajv'
+import {
+  controller,
+  get,
+  state,
+  validateState,
+} from '@tng/koa-controller'
+
+interface GetUserState {
+  userId: string
+}
+
+const getUserStateSchema: JSONSchemaType<GetUserState> = {
+  type: 'object',
+  required: ['userId'],
+  properties: {
+    userId: { type: 'string' },
+  },
+  additionalProperties: false,
+}
+
+@controller('/users')
+export class UserController {
+  @get('/:id')
+  @state({
+    userId: ['params.id'],
+  })
+  @validateState(getUserStateSchema)
+  async getUser(state: GetUserState) {
+    const { userId } = state
+
+    return { userId }
+  }
+}
+```
+
+In this pattern, `@state` builds the value, `@validateState` verifies it at runtime, and `GetUserState` provides autocomplete and compile-time checks inside the controller method.
+
+## Request logging
+
+### `loggerMW(options?)`
+
+Logs one structured object after every request. The object contains `status`, `method`, `routerName`, `duration`, `url`, and `userAgent`.
+
+```ts
+app.use(loggerMW({
+  logger,
+  inject: async (data, ctx) => ({
+    ...data,
+    traceId: ctx.traceId,
+  }),
+}))
+```
+
+Set `ctx.skipLogger = true` to suppress the request log. If `inject` throws, the middleware ignores that error and logs the base request data.
+
+## Error handling
+
+### `errorHandlerMW(options?)`
+
+Catches downstream errors and responds with:
+
+```json
+{
+  "error": "error message"
+}
+```
+
+The middleware uses `error.status` when present and defaults to HTTP 500. Errors with status 500 or greater are sent to the optional logger.
+
+```ts
+app.use(errorHandlerMW({ logger }))
+```
+
+Register `loggerMW` before `errorHandlerMW` if the request logger should observe the final error status.
+
+## Tracing and async context
+
+### `traceMW(tracer, options?)`
+
+Creates an OpenTracing span for every HTTP request, extracts an upstream span context from the request headers, and records the HTTP method, URL, and response status.
+
+```ts
+app.use(traceMW(tracer))
+```
+
+Pass `zipkinHeaderEnable: true` to fall back to Zipkin header extraction when the standard HTTP header format has no parent trace.
+
+### `alsMW(als)`
+
+Creates an isolated `AsyncLocalStorage` store for every request. Register it before `traceMW` to make the current span and trace ID available from the store:
+
+```ts
+import { AsyncLocalStorage } from 'node:async_hooks'
+import type { Span } from 'opentracing'
+import { alsMW, traceMW } from '@tng/koa-controller'
+
+interface RequestStore {
+  span?: Span
+  traceId?: string
+}
+
+const als = new AsyncLocalStorage<RequestStore>()
+
+app.use(alsMW(als))
+app.use(traceMW(tracer, { als }))
+```
+
+## Development
+
+```sh
+pnpm install
+pnpm lint
+pnpm test
+pnpm test:coverage
+pnpm build
+```
+
+The build produces both ESM (`lib/*.js`) and CommonJS (`lib/*.cjs`) entry points, plus TypeScript declarations.
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "lint": "eslint src",
-    "prepare": "npm run build",
+    "prepack": "npm run build",
     "test": "NODE_OPTIONS=\"--loader=ts-node/esm\" mocha",
     "test:coverage": "NODE_OPTIONS=\"--loader=ts-node/esm\" c8 --reporter=text-summary --reporter=html --reporter=lcov mocha"
   },

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -1,5 +1,30 @@
 import type { Middleware } from 'koa'
 
+/**
+ * Creates Koa middleware that converts downstream exceptions into JSON error
+ * responses.
+ *
+ * The response status is read from `error.status` and defaults to 500. The
+ * response body is `{ error: error.message }`. Errors with status 500 or above
+ * are passed to the optional logger together with the request method, URL,
+ * headers, and serialized request body.
+ *
+ * Register this middleware before middleware whose errors it should catch.
+ * When using `loggerMW`, register the request logger first so it observes the
+ * final response status set by this handler.
+ *
+ * @param options Error handling options.
+ * @param options.logger Optional logger with an `error` method. Only server
+ * errors with status 500 or above are logged.
+ * @returns Koa error handling middleware.
+ *
+ * @example
+ * ```ts
+ * app.use(loggerMW({ logger }))
+ * app.use(errorHandlerMW({ logger }))
+ * app.use(router.routes())
+ * ```
+ */
 export function errorHandlerMW({
   logger,
 }: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Public API for decorator-based Koa controllers, routing, validation,
+ * request-state mapping, logging, error handling, and tracing.
+ *
+ * @packageDocumentation
+ */
 export * from './router.js'
 export * from './state.js'
 export * from './error-handler.js'

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,9 +1,18 @@
 import type { Middleware as KoaMiddleware, Context as KoaContext, DefaultState } from 'koa'
 
+/**
+ * Minimal structured logger interface accepted by the package middleware.
+ * Implementations such as Pino, Winston, or `console` can be used when they
+ * provide these four methods.
+ */
 export interface Logger {
+  /** Writes an informational log entry. */
   info(...args): void
+  /** Writes a debug log entry. */
   debug(...args): void
+  /** Writes a warning log entry. */
   warn(...args): void
+  /** Writes an error log entry. */
   error(...args): void
 }
 
@@ -24,6 +33,37 @@ interface Data {
   [x: string]: unknown
 }
 
+/**
+ * Creates Koa middleware that records one structured informational log after
+ * every request.
+ *
+ * The base record contains the response status, HTTP method, registered router
+ * name, duration in milliseconds, original URL, and user agent. Set
+ * `ctx.skipLogger = true` in downstream middleware to skip a request.
+ *
+ * The middleware logs from a `finally` block. Register it before the error
+ * handler when the log should contain the status produced by that handler.
+ * Errors thrown by `inject` are ignored and the base record is logged instead.
+ *
+ * @param options Logging options.
+ * @param options.logger Logger that receives the record through `info`. When
+ * omitted, the middleware performs no output.
+ * @param options.inject Optional sync or async function used to add or replace
+ * fields in the log record.
+ * @returns Koa request logging middleware.
+ *
+ * @example
+ * ```ts
+ * app.use(loggerMW({
+ *   logger,
+ *   inject: async (data, ctx) => ({
+ *     ...data,
+ *     traceId: ctx.traceId,
+ *     userId: ctx.state.userId,
+ *   }),
+ * }))
+ * ```
+ */
 export function loggerMW({
   logger,
   inject = (d) => d,

--- a/src/router.ts
+++ b/src/router.ts
@@ -15,6 +15,13 @@ interface Context extends KoaContext {
 }
 interface Middleware extends KoaMiddleware<DefaultState, Context> { }
 
+/**
+ * A function used by {@link before} and {@link after}.
+ *
+ * The function receives the current Koa context and must return a promise.
+ * It does not receive Koa's `next` callback; use {@link middleware} when the
+ * middleware needs to wrap downstream execution.
+ */
 export interface MiddlewareFn {
   (ctx: Context): Promise<void>
 }
@@ -53,6 +60,32 @@ class MethodMeta {
   responseStream?: boolean = false
 }
 
+/**
+ * Marks a class as a controller and registers a prefix for all routes declared
+ * on that class.
+ *
+ * A controller may declare more than one prefix by applying the decorator more
+ * than once. Controller classes loaded through {@link getRouterAsync} or
+ * {@link getRouterSync} must be exported from their modules.
+ *
+ * Controller instances are created once when the router is built, so
+ * request-specific mutable data should be stored on `ctx` rather than on the
+ * controller instance.
+ *
+ * @param prefix Route prefix applied before each method pathname.
+ * @returns A class decorator.
+ *
+ * @example
+ * ```ts
+ * @controller('/api/users')
+ * export class UserController {
+ *   @get('/:id')
+ *   async getUser(state, ctx) {
+ *     return { id: ctx.params.id }
+ *   }
+ * }
+ * ```
+ */
 export function controller(prefix = '/') {
   assert.ok(prefix)
   return (constructor: ControllerConstructor) => {
@@ -67,6 +100,30 @@ export function controller(prefix = '/') {
   }
 }
 
+/**
+ * Registers standard Koa middleware on a controller class or one of its route
+ * methods.
+ *
+ * The middleware must return a promise and may run code both before and after
+ * `await next()`, following Koa's onion model. Class-level middleware runs
+ * before method-level middleware.
+ *
+ * @param middleware An async Koa middleware function.
+ * @returns A class or method decorator.
+ *
+ * @example
+ * ```ts
+ * @get('/items')
+ * @middleware(async (ctx, next) => {
+ *   const startedAt = Date.now()
+ *   await next()
+ *   ctx.set('x-duration', String(Date.now() - startedAt))
+ * })
+ * async listItems() {
+ *   return []
+ * }
+ * ```
+ */
 export function middleware(middleware: Middleware) {
   const middlewareName = middleware.name || 'middleware'
   return internalMiddleware(({controllerName, propertyName}) => async (ctx, next) => {
@@ -129,6 +186,28 @@ function internalMiddleware(mwMaker: MiddlewareMaker, { pushToBottom = false } =
   }
 }
   
+/**
+ * Registers a function that runs before the next controller middleware or
+ * route method.
+ *
+ * Use this decorator for one-way setup such as authentication checks, request
+ * normalization, or populating `ctx.state`. Use {@link middleware} instead
+ * when code must also run after the route method.
+ *
+ * @param beforeFunc Async function invoked with the current Koa context.
+ * @returns A class or method decorator.
+ *
+ * @example
+ * ```ts
+ * @before(async ctx => {
+ *   if (!ctx.get('authorization')) ctx.throw(401)
+ * })
+ * @get('/profile')
+ * async profile(state) {
+ *   return state.user
+ * }
+ * ```
+ */
 export function before(beforeFunc: MiddlewareFn) {
   const beforeName = beforeFunc.name || 'before'
   const mwMaker: MiddlewareMaker = ({ controllerName, propertyName }) => async (ctx, next) => {
@@ -146,6 +225,28 @@ export function before(beforeFunc: MiddlewareFn) {
   return internalMiddleware(mwMaker)
 }
   
+/**
+ * Registers a function that runs after the route and downstream middleware
+ * complete successfully.
+ *
+ * The callback is not invoked when downstream middleware throws. Decorate the
+ * controller class to apply the callback to every route, or decorate a method
+ * to apply it only to that route method.
+ *
+ * @param afterFunc Async function invoked with the current Koa context.
+ * @returns A class or method decorator.
+ *
+ * @example
+ * ```ts
+ * @get('/items')
+ * @after(async ctx => {
+ *   ctx.set('x-handler-complete', 'true')
+ * })
+ * async listItems() {
+ *   return []
+ * }
+ * ```
+ */
 export function after(afterFunc: MiddlewareFn) {
   const afterName = afterFunc.name || 'after'
   const mwMaker: MiddlewareMaker = ({ controllerName, propertyName }) => async (ctx, next) => {
@@ -163,6 +264,28 @@ export function after(afterFunc: MiddlewareFn) {
   return internalMiddleware(mwMaker, { pushToBottom: true })
 }
 
+/**
+ * Registers a controller method for an HTTP verb and pathname.
+ *
+ * The decorated method is called with `ctx.state` as its first argument and
+ * the Koa context as its second argument. It must return a promise; the
+ * resolved value is assigned to `ctx.body`. The same method may be registered
+ * for multiple routes by applying this decorator more than once.
+ *
+ * @param verb HTTP method understood by `koa-router`, such as `get`, `post`,
+ * `put`, `patch`, or `delete`.
+ * @param pathname Route pathname relative to the controller prefix.
+ * @returns A method decorator.
+ *
+ * @example
+ * ```ts
+ * @request('delete', '/:id')
+ * async deleteUser(state, ctx) {
+ *   await userService.remove(ctx.params.id)
+ *   ctx.status = 204
+ * }
+ * ```
+ */
 export function request(verb = 'get', pathname = '/') {
   assert.ok(verb)
   assert.ok(pathname)
@@ -185,14 +308,73 @@ export function request(verb = 'get', pathname = '/') {
   }
 }
 
+/**
+ * Registers a controller method as an HTTP GET route.
+ *
+ * This is equivalent to `@request('get', pathname)`.
+ *
+ * @param path Route pathname relative to the controller prefix.
+ * @returns A method decorator.
+ *
+ * @example
+ * ```ts
+ * @get('/:id')
+ * async getUser(state, ctx) {
+ *   return userService.find(ctx.params.id)
+ * }
+ * ```
+ */
 export function get(path = '/') {
   return request('get', path)
 }
 
+/**
+ * Registers a controller method as an HTTP POST route.
+ *
+ * This is equivalent to `@request('post', pathname)`.
+ *
+ * @param path Route pathname relative to the controller prefix.
+ * @returns A method decorator.
+ *
+ * @example
+ * ```ts
+ * @post('/')
+ * async createUser(state) {
+ *   return userService.create(state)
+ * }
+ * ```
+ */
 export function post(path = '/') {
   return request('post', path)
 }
 
+/**
+ * Builds a Koa router from an explicit list of decorated controller classes.
+ *
+ * Use this function when controller constructors are already available, for
+ * example with dependency injection or in tests. Each controller is
+ * instantiated once while the router is built. Constructors without
+ * controller/route metadata are ignored.
+ *
+ * @param options Router construction options.
+ * @param options.controllerConstructors Decorated controller classes to
+ * register.
+ * @param options.prefix Optional prefix applied to every registered route.
+ * @param options.logger Optional logger reserved for router loading.
+ * @returns A configured `koa-router` instance. Mount both `routes()` and
+ * `allowedMethods()` on the Koa application.
+ *
+ * @example
+ * ```ts
+ * const router = loadRouter({
+ *   prefix: '/v1',
+ *   controllerConstructors: [UserController],
+ * })
+ *
+ * app.use(router.routes())
+ * app.use(router.allowedMethods())
+ * ```
+ */
 export function loadRouter({
   prefix = '',
   logger: _logger,
@@ -241,6 +423,35 @@ export function loadRouter({
   return router
 }
 
+/**
+ * Discovers controller modules with a glob, loads them with `require()`, and
+ * builds a Koa router.
+ *
+ * Use this synchronous loader only when every matched controller module can be
+ * loaded by CommonJS `require()`. Each controller class must be exported from
+ * its module. Use {@link getRouterAsync} for ESM controller modules.
+ *
+ * @param options Controller discovery and router options.
+ * @param options.cwd Base directory used to resolve `files`. Defaults to
+ * `process.cwd()`.
+ * @param options.files Glob pattern for controller modules. By default it
+ * recursively matches JavaScript and TypeScript files below `api`.
+ * @param options.prefix Optional prefix applied to every registered route.
+ * @param options.logger Optional logger forwarded to {@link loadRouter}.
+ * @returns A configured `koa-router` instance.
+ *
+ * @example
+ * ```ts
+ * const router = getRouterSync({
+ *   cwd: process.cwd(),
+ *   files: 'src/controllers/*.[jt]s',
+ *   prefix: '/v1',
+ * })
+ *
+ * app.use(router.routes())
+ * app.use(router.allowedMethods())
+ * ```
+ */
 export function getRouterSync({
   cwd = process.cwd(),
   files = 'api/**/*.[jt]s',
@@ -265,8 +476,33 @@ export function getRouterSync({
 }
 
 /**
- * Async version of getRouterSync. Uses dynamic import() to load controller files,
- * works in both CJS and ESM projects. Controller files can use either module syntax.
+ * Discovers controller modules with a glob, loads them with dynamic `import()`,
+ * and builds a Koa router.
+ *
+ * This is the recommended loader for ESM projects. Every controller class must
+ * be exported from its module. Files are imported sequentially in glob result
+ * order before their exported classes are passed to {@link loadRouter}.
+ *
+ * @param options Controller discovery and router options.
+ * @param options.cwd Base directory used to resolve `files`. Defaults to
+ * `process.cwd()`.
+ * @param options.files Glob pattern for controller modules. By default it
+ * recursively matches JavaScript and TypeScript files below `api`.
+ * @param options.prefix Optional prefix applied to every registered route.
+ * @param options.logger Optional logger forwarded to {@link loadRouter}.
+ * @returns A promise resolving to a configured `koa-router` instance.
+ *
+ * @example
+ * ```ts
+ * const router = await getRouterAsync({
+ *   cwd: process.cwd(),
+ *   files: 'src/controllers/*.[jt]s',
+ *   prefix: '/v1',
+ * })
+ *
+ * app.use(router.routes())
+ * app.use(router.allowedMethods())
+ * ```
  */
 export async function getRouterAsync({
   cwd = process.cwd(),

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,6 +1,49 @@
 import lodash from 'lodash'
 import { before } from './router.js'
 
+/**
+ * Creates a method or class decorator that replaces `ctx.state` before the
+ * controller method runs.
+ *
+ * Without a mapping, the new state is a shallow merge of `ctx.query`,
+ * `ctx.request.body`, and `ctx.params`, in that order. Later sources overwrite
+ * keys from earlier sources.
+ *
+ * With a mapping, each key is resolved from one or more context paths using
+ * `lodash.get`. Paths are evaluated from left to right; when several paths are
+ * provided, each value overwrites the previous value, including `undefined`.
+ *
+ * @param params Map of state property names to context lookup paths. Omit the
+ * map to merge query, body, and route parameters into the state.
+ * @returns A class or method decorator implemented as a `before` middleware.
+ *
+ * @example
+ * ```ts
+ * interface GetUserState {
+ *   userId: string
+ *   token?: string
+ * }
+ *
+ * @get('/users/:id')
+ * @state({
+ *   userId: ['params.id'],
+ *   token: ['headers.authorization'],
+ * })
+ * async getUser(state: GetUserState) {
+ *   return userService.find(state.userId)
+ * }
+ * ```
+ *
+ * @example
+ * ```ts
+ * @post('/users')
+ * @state()
+ * async createUser(state) {
+ *   // state contains query, request body, and route parameter values.
+ *   return userService.create(state)
+ * }
+ * ```
+ */
 export function state(params?: Record<string, string[]>) {
   return before(async function stateMW (ctx) {
     if (!params) {

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -7,6 +7,7 @@ interface Context extends KoaContext {
   tracer: Tracer
   span?: Span
   routePath?: string
+  // TODO: Declare `traceId?: string` so the context type matches traceMW's runtime behavior.
 }
 
 interface Middleware extends KoaMiddleware<DefaultState, Context> { }
@@ -36,6 +37,7 @@ interface Middleware extends KoaMiddleware<DefaultState, Context> { }
  * app.use(traceMW(tracer, { als }))
  * ```
  */
+// TODO: Constrain T to an object type, or accept a store factory instead of casting an empty object to T.
 export function alsMW<T>(als: AsyncLocalStorage<T>): Middleware {
   return async (ctx, next) => {
     return als.run({} as T, () => {

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -11,6 +11,31 @@ interface Context extends KoaContext {
 
 interface Middleware extends KoaMiddleware<DefaultState, Context> { }
 
+/**
+ * Creates Koa middleware that starts a fresh AsyncLocalStorage context for
+ * every request.
+ *
+ * The store starts as an empty object and remains available to all downstream
+ * asynchronous work. Register this middleware before {@link traceMW} when the
+ * request span and trace ID should be written to the store.
+ *
+ * @typeParam T Shape of the request-local store.
+ * @param als AsyncLocalStorage instance shared by application code.
+ * @returns Koa middleware that runs downstream handlers inside a request-local
+ * store.
+ *
+ * @example
+ * ```ts
+ * interface RequestStore {
+ *   span?: Span
+ *   traceId?: string
+ * }
+ *
+ * const als = new AsyncLocalStorage<RequestStore>()
+ * app.use(alsMW(als))
+ * app.use(traceMW(tracer, { als }))
+ * ```
+ */
 export function alsMW<T>(als: AsyncLocalStorage<T>): Middleware {
   return async (ctx, next) => {
     return als.run({} as T, () => {
@@ -19,6 +44,44 @@ export function alsMW<T>(als: AsyncLocalStorage<T>): Middleware {
   }
 }
 
+/**
+ * Creates OpenTracing middleware for incoming HTTP requests.
+ *
+ * The middleware extracts a parent context from HTTP headers, creates a span,
+ * and exposes it as `ctx.span`. It also exposes a trace ID as `ctx.traceId`.
+ * When the request completes, the span records the HTTP method, URL, response
+ * status, and an error tag for 5xx responses before it is finished.
+ *
+ * If an AsyncLocalStorage instance is supplied and already has an active
+ * store, the span and trace ID are copied into that store. Register
+ * {@link alsMW} before this middleware to create the store.
+ *
+ * @typeParam T Request-local store containing optional `span` and `traceId`
+ * fields.
+ * @param tracer OpenTracing-compatible tracer used to extract context and
+ * create spans.
+ * @param options Tracing options.
+ * @param options.zipkinHeaderEnable When true, tries Zipkin HTTP header
+ * extraction if standard OpenTracing HTTP headers contain no trace ID.
+ * @param options.als Optional AsyncLocalStorage instance that receives the
+ * current span and trace ID.
+ * @returns Koa request tracing middleware.
+ *
+ * @example
+ * ```ts
+ * app.use(traceMW(tracer))
+ * ```
+ *
+ * @example
+ * ```ts
+ * const als = new AsyncLocalStorage<RequestStore>()
+ * app.use(alsMW(als))
+ * app.use(traceMW(tracer, {
+ *   als,
+ *   zipkinHeaderEnable: true,
+ * }))
+ * ```
+ */
 export function traceMW<T extends { span?: Span, traceId?: string }>(tracer: Tracer, { zipkinHeaderEnable, als }: { zipkinHeaderEnable?: boolean, als?: AsyncLocalStorage<T> } = {}): Middleware {
   return async function traceMW (ctx, next) {
     let parentSpanContext = tracer.extract(FORMAT_HTTP_HEADERS, ctx.headers)

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -3,11 +3,53 @@ import type { SchemaObject } from 'ajv'
 import createHttpError from 'http-errors'
 import { before } from './router.js'
 
+/**
+ * Shared AJV instance used by {@link validate} and {@link validateState} when
+ * a custom instance is not supplied.
+ *
+ * Type coercion and default values are enabled, so successful validation may
+ * modify the validated context or state object.
+ */
 export const globalAjvInstance = new Ajv({
   coerceTypes: true,
   useDefaults: true,
 })
 
+/**
+ * Validates the complete Koa context before a controller route runs.
+ *
+ * The schema is compiled when the decorator is created. On failure, the
+ * decorator throws an HTTP 400 error using the first AJV validation error. Use
+ * {@link validateState} when only the controller state should be validated.
+ *
+ * @param jsonSchema AJV-compatible JSON Schema applied to the Koa context.
+ * @param options Validation options.
+ * @param options.ajv AJV instance used to compile the schema. Defaults to
+ * {@link globalAjvInstance}.
+ * @returns A class or method decorator implemented as a `before` middleware.
+ * @throws An HTTP 400 error when validation fails.
+ *
+ * @example
+ * ```ts
+ * @validate({
+ *   type: 'object',
+ *   required: ['query'],
+ *   properties: {
+ *     query: {
+ *       type: 'object',
+ *       required: ['id'],
+ *       properties: {
+ *         id: { type: 'integer' },
+ *       },
+ *     },
+ *   },
+ * })
+ * @get('/users')
+ * async getUser(state, ctx) {
+ *   return userService.find(ctx.query.id)
+ * }
+ * ```
+ */
 export function validate(jsonSchema: SchemaObject, {
   ajv = globalAjvInstance,
 }: {
@@ -23,6 +65,43 @@ export function validate(jsonSchema: SchemaObject, {
   })
 }
 
+/**
+ * Validates `ctx.state` before a controller route runs.
+ *
+ * Place {@link state} above this decorator when state must first be populated
+ * from query, body, or route parameters. The schema is compiled when the
+ * decorator is created. On failure, the decorator throws an HTTP 400 error
+ * using the first AJV validation error.
+ *
+ * @param jsonSchema AJV-compatible JSON Schema applied to `ctx.state`.
+ * @param options Validation options.
+ * @param options.ajv AJV instance used to compile the schema. Defaults to
+ * {@link globalAjvInstance}.
+ * @returns A class or method decorator implemented as a `before` middleware.
+ * @throws An HTTP 400 error when validation fails.
+ *
+ * @example
+ * ```ts
+ * interface CreateUserState {
+ *   name: string
+ *   age?: number
+ * }
+ *
+ * @post('/users')
+ * @state()
+ * @validateState({
+ *   type: 'object',
+ *   required: ['name'],
+ *   properties: {
+ *     name: { type: 'string', minLength: 1 },
+ *     age: { type: 'integer', minimum: 0 },
+ *   },
+ * })
+ * async createUser(state: CreateUserState) {
+ *   return userService.create(state)
+ * }
+ * ```
+ */
 export function validateState(jsonSchema: SchemaObject, {
   ajv = globalAjvInstance,
 }: {


### PR DESCRIPTION
## Summary

- rewrite the README with installation guidance, ESM/CommonJS examples, middleware ordering, and complete API usage
- add a typed AJV state-validation example using `JSONSchemaType<T>`
- add JSDoc and examples for all public router, state, validation, logging, error-handling, and tracing APIs
- remove the project-local npm registry override

## Verification

- `pnpm lint`
- `pnpm exec tsc --noEmit -p tsconfig.json`
- `pnpm test` (52 passing)
- `pnpm build`
