### PR TITLE
fix: add --tag latest for prerelease npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Publish to npm
         if: steps.check.outputs.should_publish == 'true'
-        run: pnpm publish --access public --no-git-checks --dry-run
+        run: pnpm publish --access public --no-git-checks --tag latest --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Fix npm publish error: "You must specify a tag using --tag when publishing a prerelease version."

Added `--tag latest` to `pnpm publish` command so prerelease versions like `1.0.0-alpha.1` can be published without errors.