### PR TITLE
fix: repair release PR and publishing workflows

### DIFF
--- a/.github/workflows/abandon-release.yml
+++ b/.github/workflows/abandon-release.yml
@@ -1,0 +1,23 @@
+name: Abandon Release PR
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  cleanup:
+    if: >-
+      github.event.pull_request.merged == false &&
+      startsWith(github.event.pull_request.head.ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove pending release label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit "$PR_URL" --remove-label "autorelease: pending"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,14 +18,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Tag merged release PR and create GitHub Release
-        id: release
-        uses: googleapis/release-please-action@v4
-        with:
-          release-type: node
-          target-branch: main
-          skip-github-pull-request: true
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -38,38 +30,43 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Check whether this commit is an unpublished release
+      - name: Check whether this push merged a pending Release PR
         id: publish-check
         shell: bash
         env:
-          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          tag="$RELEASE_TAG"
-          if [ -z "$tag" ]; then
-            tag=$(git tag --list 'v*' --sort=-version:refname | head -n 1)
-          fi
+          release_pr=$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state merged \
+              --base main \
+              --label "autorelease: pending" \
+              --limit 20 \
+              --json number,mergeCommit \
+              | jq -r --arg sha "$GITHUB_SHA" \
+                '.[] | select(.mergeCommit.oid == $sha) | .number' \
+              | head -n 1
+          )
 
-          if [ -z "$tag" ]; then
-            echo "No release tag exists; skipping npm publish."
+          if [ -z "$release_pr" ]; then
+            echo "This push did not merge a pending Release PR; skipping."
             echo "should-publish=false" >> "$GITHUB_OUTPUT"
+            echo "should-finalize=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          git checkout --detach "$tag"
           version=$(node -p "require('./package.json').version")
-          if [ "$tag" != "v$version" ]; then
-            echo "Tag $tag does not match package version v$version."
-            exit 1
-          fi
-
           if npm view "@tng/koa-controller@$version" version >/dev/null 2>&1; then
             echo "@tng/koa-controller@$version is already published."
             echo "should-publish=false" >> "$GITHUB_OUTPUT"
+            echo "should-finalize=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "Publishing @tng/koa-controller@$version."
+          echo "Release PR #$release_pr will publish @tng/koa-controller@$version."
           echo "should-publish=true" >> "$GITHUB_OUTPUT"
+          echo "should-finalize=true" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         if: steps.publish-check.outputs.should-publish == 'true'
@@ -88,3 +85,11 @@ jobs:
         run: pnpm publish --access public --no-git-checks --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag the release and create GitHub Release
+        if: success() && steps.publish-check.outputs.should-finalize == 'true'
+        uses: googleapis/release-please-action@v4
+        with:
+          release-type: node
+          target-branch: main
+          skip-github-pull-request: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,6 @@ jobs:
 
       - name: Publish to npm
         if: steps.publish-check.outputs.should-publish == 'true'
-        run: pnpm publish --access public --no-git-checks --tag latest --dry-run
+        run: pnpm publish --access public --no-git-checks --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,6 @@ jobs:
 
       - name: Publish to npm
         if: steps.publish-check.outputs.should-publish == 'true'
-        run: pnpm publish --access public --no-git-checks --tag latest
+        run: pnpm publish --access public --no-git-checks --tag latest --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,31 @@
-name: Publish to npm
+name: Publish Release
 
 on:
   push:
     branches: [main]
 
+concurrency:
+  group: publish-release
+  cancel-in-progress: false
+
 permissions:
   contents: write
+  pull-requests: write
+  issues: write
   id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Tag merged release PR and create GitHub Release
+        id: release
+        uses: googleapis/release-please-action@v4
+        with:
+          release-type: node
+          target-branch: main
+          skip-github-pull-request: true
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -24,41 +38,53 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Check if new version
-        id: check
+      - name: Check whether this commit is an unpublished release
+        id: publish-check
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            echo "Tag v$VERSION already exists, skipping."
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "New version detected: v$VERSION"
-            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          tag="$RELEASE_TAG"
+          if [ -z "$tag" ]; then
+            tag=$(git tag --list 'v*' --sort=-version:refname | head -n 1)
           fi
 
+          if [ -z "$tag" ]; then
+            echo "No release tag exists; skipping npm publish."
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git checkout --detach "$tag"
+          version=$(node -p "require('./package.json').version")
+          if [ "$tag" != "v$version" ]; then
+            echo "Tag $tag does not match package version v$version."
+            exit 1
+          fi
+
+          if npm view "@tng/koa-controller@$version" version >/dev/null 2>&1; then
+            echo "@tng/koa-controller@$version is already published."
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Publishing @tng/koa-controller@$version."
+          echo "should-publish=true" >> "$GITHUB_OUTPUT"
+
       - name: Install dependencies
-        if: steps.check.outputs.should_publish == 'true'
+        if: steps.publish-check.outputs.should-publish == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build package
-        if: steps.check.outputs.should_publish == 'true'
+        if: steps.publish-check.outputs.should-publish == 'true'
         run: pnpm build
 
       - name: Verify package contents
-        if: steps.check.outputs.should_publish == 'true'
+        if: steps.publish-check.outputs.should-publish == 'true'
         run: npm pack --dry-run
 
       - name: Publish to npm
-        if: steps.check.outputs.should_publish == 'true'
-        run: pnpm publish --access public --no-git-checks --tag latest --dry-run
+        if: steps.publish-check.outputs.should-publish == 'true'
+        run: pnpm publish --access public --no-git-checks --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create and push git tag
-        if: steps.check.outputs.should_publish == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.check.outputs.version }}" -m "Release v${{ steps.check.outputs.version }}"
-          git push origin "v${{ steps.check.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,23 @@ permissions:
 
 jobs:
   release-please:
+    if: github.ref_name == 'main' || github.ref_name == 'fix/release'
     runs-on: ubuntu-latest
     steps:
+      - name: Debug inputs
+        env:
+          VERSION_FROM_INPUTS: ${{ inputs.version }}
+          VERSION_FROM_EVENT: ${{ github.event.inputs.version }}
+        run: |
+          printf 'event_name=%s\n' "$GITHUB_EVENT_NAME"
+          printf 'ref=%s\n' "$GITHUB_REF"
+          printf 'ref_name=%s\n' "$GITHUB_REF_NAME"
+          printf 'version from inputs=%s\n' "$VERSION_FROM_INPUTS"
+          printf 'version from github.event.inputs=%s\n' "$VERSION_FROM_EVENT"
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: node
           skip-github-release: true
-          release-as: ${{ github.event.inputs.version || '' }}
-
+          release-as: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
         required: false
         default: ''
         type: string
+concurrency:
+  group: create-release-pr
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -15,24 +18,22 @@ permissions:
   issues: write
 
 jobs:
-  release-please:
-    if: github.ref_name == 'main' || github.ref_name == 'fix/release'
+  create-release-pr:
     runs-on: ubuntu-latest
     steps:
-      - name: Debug inputs
-        env:
-          VERSION_FROM_INPUTS: ${{ inputs.version }}
-          VERSION_FROM_EVENT: ${{ github.event.inputs.version }}
-        run: |
-          printf 'event_name=%s\n' "$GITHUB_EVENT_NAME"
-          printf 'ref=%s\n' "$GITHUB_REF"
-          printf 'ref_name=%s\n' "$GITHUB_REF_NAME"
-          printf 'version from inputs=%s\n' "$VERSION_FROM_INPUTS"
-          printf 'version from github.event.inputs=%s\n' "$VERSION_FROM_EVENT"
-
-      - uses: googleapis/release-please-action@v4
-        id: release
+      - name: Create an automatically versioned release PR
+        if: inputs.version == ''
+        uses: googleapis/release-please-action@v4
         with:
           release-type: node
+          target-branch: main
+          skip-github-release: true
+
+      - name: Create a release PR for the requested version
+        if: inputs.version != ''
+        uses: googleapis/release-please-action@v4
+        with:
+          release-type: node
+          target-branch: main
           skip-github-release: true
           release-as: ${{ inputs.version }}


### PR DESCRIPTION
Separate manual Release PR creation from post-merge publishing. Complete release-please lifecycle tagging, clean up abandoned pending labels, support automatic or explicit versions, and enable real npm publishing after a release is finalized.